### PR TITLE
Publish for Scala 2.11.0-M4

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.1
+sbt.version=0.12.+

--- a/project/build.scala
+++ b/project/build.scala
@@ -14,8 +14,8 @@ object MigraitonDef extends Build {
     organization := "org.scala-lang",
     name := "scala-actors-migration",
     version := "1.0.0",
-    scalaVersion := "2.10.0",
-    // scalaBinaryVersion <<= scalaVersion,
+    scalaVersion := "2.11.0-M4",
+    scalaBinaryVersion <<= scalaVersion,
     parallelExecution in Test := true,
     resolvers += "junit interface repo" at "https://repository.jboss.org/nexus/content/repositories/scala-tools-releases",
     resolvers += "Sonatype Snapshots repo" at "https://oss.sonatype.org/content/repositories/snapshots/",
@@ -23,6 +23,7 @@ object MigraitonDef extends Build {
     libraryDependencies <++= scalaVersion apply dependencies) settings (publishSettings: _*) settings (websiteSettings: _*))
 
   def publishSettings: Seq[Setting[_]] = Seq(
+    credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
     // If we want on maven central, we need to be in maven style.
     publishMavenStyle := true,
     publishArtifact in Test := false,


### PR DESCRIPTION
Published using `publish-signed`.

With pgp plugin loaded in ~/.sbt/plugins/plugins.sbt:

```
addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
```

Using sonatype with ~/.ivy2/.credentials:

```
realm=Sonatype Nexus Repository Manager
host=oss.sonatype.org
user=???
password=???
```

Upgraded SBT version to the latest 0.12,
as 0.12.1 had a bug that kept me from publishing.

review by @vjovanov
